### PR TITLE
Return family in DNS lookup callback

### DIFF
--- a/evil-dns.js
+++ b/evil-dns.js
@@ -24,9 +24,10 @@ dns.lookup = function(domain, options, callback) {
 	}
 
 	for (i = 0; i < domains.length; i++) {
-		if (domain.match(domains[i].domain)) {
-			if (!family || family === domain[i].family) {
-				return callback(null, domains[i].ip, family);
+		var entry = domains[i];
+		if (domain.match(entry.domain)) {
+			if (!family || family === entry.family) {
+				return callback(null, entry.ip, entry.family);
 			}			
 		}
 	}

--- a/tests/lookup.tests.js
+++ b/tests/lookup.tests.js
@@ -3,16 +3,29 @@ var expect = require('chai').expect;
 var evilDNS = require('../evil-dns');
 
 describe('The method hijacking dns.lookup', function () {
-    it('handles family-agnostic queries', function (done) {
-        var error = null;
-        try {
-            dns.lookup('nodejs.org', { family: undefined, hints: dns.ADDRCONFIG | dns.V4MAPPED }, function (err) {
-                expect(err).to.not.exist;
-                done();
-            });
-        } catch (err) {
-            expect(err).to.not.exist;
-            done();
-        }
+  it('returns the family when doing DNS queries', function (done) {
+    evilDNS.add('*.foo.com', '1.2.3.4');
+    dns.lookup('a.foo.com', {family: undefined, hints: dns.ADDRCONFIG | dns.V4MAPPED}, function (err, addr, family) {
+      expect(addr).to.equal('1.2.3.4');
+      expect(family).to.equal(4);
+      done();
     });
+  });
+
+  it('handles family-agnostic queries', function (done) {
+    var error = null;
+    try {
+      dns.lookup('nodejs.org', {family: undefined, hints: dns.ADDRCONFIG | dns.V4MAPPED}, function (err) {
+        expect(err).to.not.exist;
+        done();
+      });
+    } catch (err) {
+      expect(err).to.not.exist;
+      done();
+    }
+  });
+
+  afterEach(function () {
+    evilDNS.clear();
+  });
 });


### PR DESCRIPTION
At least in node v0.12.1 on Windows, I was getting assert errors when trying to connect to an address hijacked by `evil-dns`. It turned out to be because the family was not being provided during lookup. When sending the address family to the callback, this was fixed.
