### PR TITLE
add support for node 0.10

### DIFF
--- a/evil-dns.js
+++ b/evil-dns.js
@@ -9,14 +9,16 @@ var dns = require('dns'),
 
 dns.lookup = function(domain, options, callback) {
 	var i;
+	var _options = options;
+	var _callback = callback;
 
 	if (arguments.length === 2) {
-		callback = options;
-		options = {};
-	} 
+		_callback = _options;
+		_options = {};
+	}
 
-    var family = (typeof(options) === 'object') ? options.family : options;
-    if (family) {
+	var family = (typeof(_options) === 'object') ? _options.family : _options;
+	if (family) {
 		family = +family;
 		if (family !== 4 && family !== 6) {
 			throw new Error('invalid argument: `family` must be 4 or 6');
@@ -27,12 +29,12 @@ dns.lookup = function(domain, options, callback) {
 		var entry = domains[i];
 		if (domain.match(entry.domain)) {
 			if (!family || family === entry.family) {
-				return callback(null, entry.ip, entry.family);
-			}			
+				return _callback(null, entry.ip, entry.family);
+			}
 		}
 	}
 
-	return dnsLookup.call(this, domain, options, callback);
+	return dnsLookup.apply(this, arguments);
 };
 
 /**

--- a/tests/lookup.tests.js
+++ b/tests/lookup.tests.js
@@ -14,8 +14,28 @@ describe('The method hijacking dns.lookup', function () {
 
   it('handles family-agnostic queries', function (done) {
     var error = null;
+    var options = {family: undefined, hints: dns.ADDRCONFIG | dns.V4MAPPED};
+
+    if (/^0\.10/.test(process.versions.node) || /^0\.11/.test(process.versions.node)) {
+      options = 4;
+    }
+
     try {
-      dns.lookup('nodejs.org', {family: undefined, hints: dns.ADDRCONFIG | dns.V4MAPPED}, function (err) {
+      dns.lookup('nodejs.org', options, function (err) {
+        expect(err).to.not.exist;
+        done();
+      });
+    } catch (err) {
+      expect(err).to.not.exist;
+      done();
+    }
+  });
+
+  it('handles empty options', function (done) {
+    var error = null;
+
+    try {
+      dns.lookup('nodejs.org', function (err) {
         expect(err).to.not.exist;
         done();
       });


### PR DESCRIPTION
When the lookup hijack didn't hit the target and passthrough to the original lookup function, error errors on node 0.10. 

In current code, if the options argument is not specified, it is set to empty object. However in node 0.10, if option is passed to lookup function as empty object, error will get thrown. https://github.com/nodejs/node/blob/615a35ccd2cb5cba80901862aefe51a940995f44/lib/dns.js#L89-L92

In this pr, to avoid modifying the original arguments, I make a copy of the options and callback argument when hijacking. So if target domain is not hit, the original lookup function get called as the same as without hijack.
